### PR TITLE
add validation error code

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -467,7 +467,8 @@ VDI Plugin Handler Server.
 [source]
 ----
 0    - Success
-1+   - Failure due to unxpected/undefined error.
+1    - Failure due to validation error.
+2+   - Failure due to unxpected/undefined error.
 ----
 
 === Uninstall Script

--- a/service/api.raml
+++ b/service/api.raml
@@ -122,7 +122,7 @@ description: |
             type: object
             additionalProperties: false
             properties:
-              messages:
+              warnings:
                 type: array
                 items:
                   type: string
@@ -221,6 +221,20 @@ description: |
           body:
             application/json:
               type: SimpleError
+        418:
+          description: |
+            Validation Failure
+            
+            The posted dataset failed the install process validation step.
+          body:
+            application/json:
+              type: object
+              additionalProperties: false
+              properties:
+                warnings:
+                  type: array
+                  items:
+                    type: string
         500:
           description: |
             Internal Server Error

--- a/service/src/main/kotlin/vdi/consts/ExitCode.kt
+++ b/service/src/main/kotlin/vdi/consts/ExitCode.kt
@@ -4,4 +4,7 @@ object ExitCode {
   const val ImportScriptSuccess               = 0
   const val ImportScriptValidationFailure     = 1
   const val ImportScriptTransformationFailure = 2
+
+  const val InstallScriptSuccess           = 0
+  const val InstallScriptValidationFailure = 1
 }

--- a/service/src/main/kotlin/vdi/server/controller/install-data.kt
+++ b/service/src/main/kotlin/vdi/server/controller/install-data.kt
@@ -5,26 +5,32 @@ import vdi.model.ApplicationContext
 import vdi.server.context.withDatabaseDetails
 import vdi.server.context.withInstallDataContext
 import vdi.server.model.InstallDataSuccessResponse
+import vdi.server.model.WarningsListResponse
 import vdi.server.respondJSON200
+import vdi.server.respondJSON418
 import vdi.service.InstallDataHandler
 
 suspend fun ApplicationCall.handleInstallDataRequest(appCtx: ApplicationContext) {
   withInstallDataContext { workspace, details, payload ->
     withDatabaseDetails(appCtx.config.databases, appCtx.ldap, details.projectID) { dbDetails ->
-      // Run the install-data service and collect the returned list of
-      // installation warnings.
-      val warnings = InstallDataHandler(
-        workspace,
-        details.vdiID,
-        payload,
-        dbDetails,
-        appCtx.executor,
-        appCtx.config.service.installDataScript,
-        appCtx.metrics.scriptMetrics,
-      )
-        .run()
+      try {
+        // Run the install-data service and collect the returned list of
+        // installation warnings.
+        val warnings = InstallDataHandler(
+          workspace,
+          details.vdiID,
+          payload,
+          dbDetails,
+          appCtx.executor,
+          appCtx.config.service.installDataScript,
+          appCtx.metrics.scriptMetrics,
+        )
+          .run()
 
-      respondJSON200(InstallDataSuccessResponse(warnings))
+        respondJSON200(InstallDataSuccessResponse(warnings))
+      } catch (e: InstallDataHandler.ValidationError) {
+        respondJSON418(WarningsListResponse(e.warnings))
+      }
     }
   }
 }

--- a/service/src/main/kotlin/vdi/service/InstallDataHandler.kt
+++ b/service/src/main/kotlin/vdi/service/InstallDataHandler.kt
@@ -12,6 +12,7 @@ import vdi.components.io.LoggingOutputStream
 import vdi.components.metrics.ScriptMetrics
 import vdi.components.script.ScriptExecutor
 import vdi.conf.ScriptConfiguration
+import vdi.consts.ExitCode
 import vdi.model.DatabaseDetails
 import vdi.util.unpackAsTarGZ
 
@@ -71,8 +72,13 @@ class InstallDataHandler(
         job2.join()
 
         when (exitCode()) {
-          0    -> {
-            log.debug("install-data script completed successfully for VDI dataset ID {}", vdiID)
+          ExitCode.InstallScriptSuccess -> {
+            log.info("install-data script completed successfully for VDI dataset ID {}", vdiID)
+          }
+
+          ExitCode.InstallScriptValidationFailure -> {
+            log.info("install-data script refused to install VDI dataset {} for validation errors", vdiID)
+            throw ValidationError(warnings)
           }
 
           else -> {
@@ -86,4 +92,6 @@ class InstallDataHandler(
 
     return warnings
   }
+
+  class ValidationError(val warnings: Collection<String>) : RuntimeException()
 }


### PR DESCRIPTION
### Changes

* Adds a catch clause for a validation error exit code from the install-data script (exit code `1`).
* Adds a validation error response code from the HTTP service
* Updates the docs to show the exit code for validation error in the install-data step