### PR TITLE
Add project id to install meta and install data

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -364,12 +364,13 @@ The `meta.json` file will exist for the duration of the script's execution.
 
 [%header, cols="2m,8"]
 |===
-| Variable | Description
-| DB_HOST  | Database connection hostname.
-| DB_PORT  | Database connection port.
-| DB_NAME  | Target database name.
-| DB_USER  | Database credentials username.
-| DB_PASS  | Database credentials password.
+| Variable   | Description
+| DB_HOST    | Database connection hostname.
+| DB_PORT    | Database connection port.
+| DB_NAME    | Target database name.
+| DB_USER    | Database credentials username.
+| DB_PASS    | Database credentials password.
+| PROJECT_ID | Project ID for the target project the dataset should be installed into.
 |===
 
 ==== Outputs
@@ -430,12 +431,13 @@ completes its execution.
 
 [%header, cols="2m,8"]
 |===
-| Variable | Description
-| DB_HOST  | Database connection hostname.
-| DB_PORT  | Database connection port.
-| DB_NAME  | Target database name.
-| DB_USER  | Database credentials username.
-| DB_PASS  | Database credentials password.
+| Variable   | Description
+| DB_HOST    | Database connection hostname.
+| DB_PORT    | Database connection port.
+| DB_NAME    | Target database name.
+| DB_USER    | Database credentials username.
+| DB_PASS    | Database credentials password.
+| PROJECT_ID | Project ID for the target project the dataset should be installed into.
 |===
 
 ==== Outputs

--- a/service/src/main/kotlin/vdi/server/controller/install-data.kt
+++ b/service/src/main/kotlin/vdi/server/controller/install-data.kt
@@ -19,6 +19,7 @@ suspend fun ApplicationCall.handleInstallDataRequest(appCtx: ApplicationContext)
         val warnings = InstallDataHandler(
           workspace,
           details.vdiID,
+          details.projectID,
           payload,
           dbDetails,
           appCtx.executor,

--- a/service/src/main/kotlin/vdi/server/controller/install-meta.kt
+++ b/service/src/main/kotlin/vdi/server/controller/install-meta.kt
@@ -13,6 +13,7 @@ suspend fun ApplicationCall.handleInstallMetaRequest(appCtx: ApplicationContext)
       InstallMetaHandler(
         workspace,
         request.vdiID,
+        request.projectID,
         request.meta,
         dbDetails,
         appCtx.executor,


### PR DESCRIPTION
Adds an environment variable for `PROJECT_ID` to the installation script call context for `install-meta` and `install-data`.