### PR TITLE
Update the defaults to use the bin directory.

### DIFF
--- a/service/src/main/kotlin/vdi/consts/ConfigDefault.kt
+++ b/service/src/main/kotlin/vdi/consts/ConfigDefault.kt
@@ -5,10 +5,10 @@ object ConfigDefault {
   const val ServerPort = "80"
   const val ServerHost = "0.0.0.0"
 
-  const val ImportScriptPath = "/opt/veupathdb/import"
-  const val DataInstallScriptPath = "/opt/veupathdb/install-data"
-  const val MetaInstallScriptPath = "/opt/veupathdb/install-meta"
-  const val UninstallScriptPath = "/opt/veupathdb/uninstall"
+  const val ImportScriptPath = "/opt/veupathdb/bin/import"
+  const val DataInstallScriptPath = "/opt/veupathdb/bin/install-data"
+  const val MetaInstallScriptPath = "/opt/veupathdb/bin/install-meta"
+  const val UninstallScriptPath = "/opt/veupathdb/bin/uninstall"
 
   const val ImportScriptMaxDuration = "1h"
   const val DataInstallScriptMaxDuration = "1h"


### PR DESCRIPTION
It was decided that the runnable scripts will live in a `/bin` subdirectory.  This PR updates the defaults in the service to reflect that.  The other instances of these paths have already been updated in the template repo env file.