### PR TITLE
Add meta.json path to args for `install-data` script.

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -364,13 +364,14 @@ The `meta.json` file will exist for the duration of the script's execution.
 
 [%header, cols="2m,8"]
 |===
-| Variable   | Description
-| DB_HOST    | Database connection hostname.
-| DB_PORT    | Database connection port.
-| DB_NAME    | Target database name.
-| DB_USER    | Database credentials username.
-| DB_PASS    | Database credentials password.
-| PROJECT_ID | Project ID for the target project the dataset should be installed into.
+| Variable    | Description
+| DB_HOST     | Database connection hostname.
+| DB_PORT     | Database connection port.
+| DB_NAME     | Target database name.
+| DB_USER     | Database credentials username.
+| DB_PASS     | Database credentials password.
+| DB_PLATFORM | Database platform type (`oracle\|postgresql`)
+| PROJECT_ID  | Project ID for the target project the dataset should be installed into.
 |===
 
 ==== Outputs
@@ -415,13 +416,13 @@ directory containing the contents of the dataset to be installed.
 .Structure
 [source, shell-session]
 ----
-$ install-data {vdi-id} {path-to-dataset-files}
+$ install-data {vdi-id} {path-to-meta-json} {path-to-dataset-files}
 ----
 
 .Example
 [source, shell-session]
 ----
-$ install-data bfcb312a5875ae38536a64e60055c74e /path/to/dataset/files
+$ install-data bfcb312a5875ae38536a64e60055c74e /path/to/dataset/meta.json /path/to/dataset/files
 ----
 
 The input directory is temporary and will be removed as soon as the script
@@ -431,13 +432,14 @@ completes its execution.
 
 [%header, cols="2m,8"]
 |===
-| Variable   | Description
-| DB_HOST    | Database connection hostname.
-| DB_PORT    | Database connection port.
-| DB_NAME    | Target database name.
-| DB_USER    | Database credentials username.
-| DB_PASS    | Database credentials password.
-| PROJECT_ID | Project ID for the target project the dataset should be installed into.
+| Variable    | Description
+| DB_HOST     | Database connection hostname.
+| DB_PORT     | Database connection port.
+| DB_NAME     | Target database name.
+| DB_USER     | Database credentials username.
+| DB_PASS     | Database credentials password.
+| DB_PLATFORM | Database platform type (`oracle\|postgresql`)
+| PROJECT_ID  | Project ID for the target project the dataset should be installed into.
 |===
 
 ==== Outputs
@@ -500,12 +502,13 @@ $ uninstall bfcb312a5875ae38536a64e60055c74e
 
 [%header, cols="2m,8"]
 |===
-| Variable | Description
-| DB_HOST  | Database connection hostname.
-| DB_PORT  | Database connection port.
-| DB_NAME  | Target database name.
-| DB_USER  | Database credentials username.
-| DB_PASS  | Database credentials password.
+| Variable    | Description
+| DB_HOST     | Database connection hostname.
+| DB_PORT     | Database connection port.
+| DB_NAME     | Target database name.
+| DB_USER     | Database credentials username.
+| DB_PASS     | Database credentials password.
+| DB_PLATFORM | Database platform type (`oracle\|postgresql`)
 |===
 
 ==== Outputs

--- a/service/src/main/kotlin/vdi/service/InstallDataHandler.kt
+++ b/service/src/main/kotlin/vdi/service/InstallDataHandler.kt
@@ -103,7 +103,7 @@ class InstallDataHandler(
     executor.executeScript(
       dataScript.path,
       workspace,
-      arrayOf(vdiID, installDir.absolutePathString()),
+      arrayOf(vdiID, installDir.resolve(FileName.MetaFileName).absolutePathString(), installDir.absolutePathString()),
       buildScriptEnv()
     ) {
       coroutineScope {


### PR DESCRIPTION
Adds a new argument between the original 2 for the path to the meta.json file on the `install-data` script.  The new CLI signature is:
```
install-data {vdi-id} {path-to-meta-json} {path-to-dataset-files}
```