### PR TITLE
Add CUSTOM_PATH environment variable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  kotlin("jvm") version "1.8.0"
+  kotlin("jvm") version "1.8.21"
 }
 
 allprojects {

--- a/example.env
+++ b/example.env
@@ -1,6 +1,7 @@
 #
 #   HTTP Server Configuration
 #
+
 SERVER_PORT=8080
 SERVER_HOST=0.0.0.0
 
@@ -8,29 +9,69 @@ SERVER_HOST=0.0.0.0
 #
 #   VDI Plugin Service Configuration
 #
+
+# Comma separated list of ldap server hostname:port pairs that the service will
+# attempt to connect to when attempting to look up oracle connection details for
+# target application databases.
 LDAP_SERVER=
+
+# Base distinguished name to use when searching for LDAP entries for target
+# application databases.
 ORACLE_BASE_DN=
 
+
+# Path to the import script/executable in the built container.
 IMPORT_SCRIPT_PATH=/opt/veupathdb/bin/import
+
+# Max duration the script will be allowed to run before being killed by the
+# plugin handler service.
 IMPORT_SCRIPT_MAX_DURATION=1h
 
+
+# Path to the check-compatibility script/executable in the built container.
 CHECK_COMPAT_SCRIPT_PATH=/opt/veupathdb/bin/check-compatibility
+
+# Max duration the script will be allowed to run before being killed by the
+# plugin handler service.
 CHECK_COMPAT_SCRIPT_MAX_DURATION=5m
 
+
+# Path to the install-data script/executable in the built container.
 INSTALL_DATA_SCRIPT_PATH=/opt/veupathdb/bin/install-data
+
+# Max duration the script will be allowed to run before being killed by the
+# plugin handler service.
 INSTALL_DATA_SCRIPT_MAX_DURATION=1h
 
+
+# Path to the install-meta script/executable in the built container.
 INSTALL_META_SCRIPT_PATH=/opt/veupathdb/bin/install-meta
+
+# Max duration the script will be allowed to run before being killed by the
+# plugin handler service.
 INSTALL_META_SCRIPT_MAX_DURATION=1h
 
+
+# Path to the uninstall script/executable in the built container.
 UNINSTALL_SCRIPT_PATH=/opt/veupathdb/bin/uninstall
+
+# Max duration the script will be allowed to run before being killed by the
+# plugin handler service.
 UNINSTALL_SCRIPT_MAX_DURATION=1h
+
+
+# Custom $PATH environment variable entries that will be appended to the $PATH
+# variable passed to scripts on execution.
+#
+# This value should resemble a standard $PATH variable, with colon (:) separated
+# paths to locations in the built container.
+CUSTOM_PATH=
 
 
 #
 #   Database Connection Configurations
 #
 DB_CONNECTION_NAME_EXAMPLE=ExampleDB
-DB_CONNECTION_LDAP_EXAMPLE=some LDAP query
+DB_CONNECTION_LDAP_EXAMPLE=some LDAP service name
 DB_CONNECTION_USER_EXAMPLE=someusername
 DB_CONNECTION_PASS_EXAMPLE=somepassword

--- a/service/src/main/kotlin/vdi/conf/ServiceConfiguration.kt
+++ b/service/src/main/kotlin/vdi/conf/ServiceConfiguration.kt
@@ -20,6 +20,8 @@ data class ServiceConfiguration(
   val installMetaScript: ScriptConfiguration,
   val uninstallScript: ScriptConfiguration,
   val checkCompatScript: ScriptConfiguration,
+
+  val customPath: String,
 ) {
   constructor(env: EnvironmentAccessor) : this(
     env.require(ConfigEnvKey.LDAPServer),
@@ -44,6 +46,7 @@ data class ServiceConfiguration(
       env.optional(ConfigEnvKey.CheckCompatScriptPath) ?: ConfigDefault.CheckCompatScriptPath,
       (env.optional(ConfigEnvKey.CheckCompatScriptMaxDuration) ?: ConfigDefault.CheckCompatScriptMaxDuration).toDurSeconds(),
     ),
+    env.optional(ConfigEnvKey.CustomPath) ?: ConfigDefault.CustomPath
   )
 }
 

--- a/service/src/main/kotlin/vdi/consts/ConfigDefault.kt
+++ b/service/src/main/kotlin/vdi/consts/ConfigDefault.kt
@@ -11,6 +11,8 @@ object ConfigDefault {
   const val UninstallScriptPath = "/opt/veupathdb/bin/uninstall"
   const val CheckCompatScriptPath = "/opt/veupathdb/bin/check-compatibility"
 
+  const val CustomPath = ""
+
   const val ImportScriptMaxDuration = "1h"
   const val DataInstallScriptMaxDuration = "1h"
   const val MetaInstallScriptMaxDuration = "1h"

--- a/service/src/main/kotlin/vdi/consts/ConfigEnvKey.kt
+++ b/service/src/main/kotlin/vdi/consts/ConfigEnvKey.kt
@@ -25,4 +25,6 @@ object ConfigEnvKey {
 
   const val ServerPort = "SERVER_PORT"
   const val ServerHost = "SERVER_HOST"
+
+  const val CustomPath = "CUSTOM_PATH"
 }

--- a/service/src/main/kotlin/vdi/server/controller/import.kt
+++ b/service/src/main/kotlin/vdi/server/controller/import.kt
@@ -21,6 +21,7 @@ suspend fun ApplicationCall.handleImportRequest(appCtx: ApplicationContext) {
         details,
         appCtx.executor,
         appCtx.config.service.importScript,
+        appCtx.config.service.customPath,
         appCtx.metrics.scriptMetrics,
       )
         .run()

--- a/service/src/main/kotlin/vdi/server/controller/install-data.kt
+++ b/service/src/main/kotlin/vdi/server/controller/install-data.kt
@@ -24,6 +24,7 @@ suspend fun ApplicationCall.handleInstallDataRequest(appCtx: ApplicationContext)
           payload,
           dbDetails,
           appCtx.executor,
+          appCtx.config.service.customPath,
           appCtx.config.service.installMetaScript,
           appCtx.config.service.installDataScript,
           appCtx.config.service.checkCompatScript,

--- a/service/src/main/kotlin/vdi/server/controller/install-meta.kt
+++ b/service/src/main/kotlin/vdi/server/controller/install-meta.kt
@@ -17,6 +17,7 @@ suspend fun ApplicationCall.handleInstallMetaRequest(appCtx: ApplicationContext)
         request.meta,
         dbDetails,
         appCtx.executor,
+        appCtx.config.service.customPath,
         appCtx.config.service.installMetaScript,
         appCtx.metrics.scriptMetrics,
       )

--- a/service/src/main/kotlin/vdi/server/controller/uninstall.kt
+++ b/service/src/main/kotlin/vdi/server/controller/uninstall.kt
@@ -15,6 +15,7 @@ suspend fun ApplicationCall.handleUninstallRequest(appCtx: ApplicationContext) {
         vdiID,
         dbDetails,
         appCtx.executor,
+        appCtx.config.service.customPath,
         appCtx.config.service.uninstallScript,
         appCtx.metrics.scriptMetrics,
       )

--- a/service/src/main/kotlin/vdi/service/HandlerBase.kt
+++ b/service/src/main/kotlin/vdi/service/HandlerBase.kt
@@ -1,13 +1,30 @@
 package vdi.service
 
 import org.slf4j.LoggerFactory
+import org.veupathdb.vdi.lib.common.env.Environment
 import java.nio.file.Path
 import vdi.components.metrics.ScriptMetrics
 import vdi.components.script.ScriptExecutor
 
 sealed class HandlerBase<T>(
+  /**
+   * Path to the workspace for the script execution.
+   */
   protected val workspace: Path,
+
+  /**
+   * Script executor service.
+   */
   protected val executor: ScriptExecutor,
+
+  /**
+   * Custom PATH environment variable entries
+   */
+  protected val customPath: String,
+
+  /**
+   * Metrics collector.
+   */
   protected val metrics: ScriptMetrics,
 ) {
   private val log = LoggerFactory.getLogger(javaClass)
@@ -18,5 +35,11 @@ sealed class HandlerBase<T>(
 
   abstract suspend fun run(): T
 
-  protected abstract fun buildScriptEnv(): Map<String, String>
+  protected fun buildScriptEnv(): Environment =
+    if (customPath.isBlank())
+      mutableMapOf("PATH" to System.getenv("PATH"))
+    else
+      mutableMapOf("PATH" to System.getenv("PATH") + ':' + customPath)
+
+  protected open fun appendScriptEnv(env: MutableMap<String, String>) {}
 }

--- a/service/src/main/kotlin/vdi/service/ImportHandler.kt
+++ b/service/src/main/kotlin/vdi/service/ImportHandler.kt
@@ -29,8 +29,9 @@ class ImportHandler(
   private val details: ImportDetails,
   executor:  ScriptExecutor,
   private val script: ScriptConfiguration,
+  customPath: String,
   metrics: ScriptMetrics,
-) : HandlerBase<Path>(workspace, executor, metrics) {
+) : HandlerBase<Path>(workspace, executor, customPath, metrics) {
   private val log = LoggerFactory.getLogger(javaClass)
 
   private val inputDirectory: Path = workspace.resolve(INPUT_DIRECTORY_NAME)
@@ -57,8 +58,6 @@ class ImportHandler(
       .also { outputFiles.packAsTarGZ(it) }
       .also { outputDirectory.deleteRecursively() }
   }
-
-  override fun buildScriptEnv(): Map<String, String> = emptyMap()
 
   /**
    * Unpacks the given input archive into the input directory and ensures that

--- a/service/src/main/kotlin/vdi/service/InstallDataHandler.kt
+++ b/service/src/main/kotlin/vdi/service/InstallDataHandler.kt
@@ -2,6 +2,7 @@ package vdi.service
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.slf4j.LoggerFactory
+import org.veupathdb.vdi.lib.common.env.Environment
 import org.veupathdb.vdi.lib.common.model.VDIDatasetMeta
 import org.veupathdb.vdi.lib.json.JSON
 import java.io.OutputStreamWriter
@@ -26,11 +27,12 @@ class InstallDataHandler(
   private val payload: Path,
   private val dbDetails: DatabaseDetails,
   executor: ScriptExecutor,
+  customPath: String,
   private val metaScript: ScriptConfiguration,
   private val dataScript: ScriptConfiguration,
   private val compatScript: ScriptConfiguration,
   metrics: ScriptMetrics,
-) : HandlerBase<List<String>>(workspace, executor, metrics) {
+) : HandlerBase<List<String>>(workspace, executor, customPath, metrics) {
   private val log = LoggerFactory.getLogger(javaClass)
 
   init {
@@ -72,11 +74,9 @@ class InstallDataHandler(
     return warnings
   }
 
-  override fun buildScriptEnv(): Map<String, String> {
-    val out = HashMap<String, String>(12)
-    out.putAll(dbDetails.toEnvMap())
-    out["PROJECT_ID"] = projectID
-    return out
+  override fun appendScriptEnv(env: MutableMap<String, String>) {
+    env.putAll(dbDetails.toEnvMap())
+    env["PROJECT_ID"] = projectID
   }
 
   private suspend fun runInstallMeta(metaFile: Path) {

--- a/service/src/main/kotlin/vdi/service/InstallMetaHandler.kt
+++ b/service/src/main/kotlin/vdi/service/InstallMetaHandler.kt
@@ -23,9 +23,10 @@ class InstallMetaHandler(
   private val meta: VDIDatasetMeta,
   private val dbDetails: DatabaseDetails,
   executor:  ScriptExecutor,
+  customPath: String,
   private val script: ScriptConfiguration,
   metrics: ScriptMetrics,
-) : HandlerBase<Unit>(workspace, executor, metrics) {
+) : HandlerBase<Unit>(workspace, executor, customPath, metrics) {
   private val log = LoggerFactory.getLogger(javaClass)
 
   override suspend fun run() {
@@ -60,10 +61,8 @@ class InstallMetaHandler(
     timer.observeDuration()
   }
 
-  override fun buildScriptEnv(): Map<String, String> {
-    val out = HashMap<String, String>(12)
-    out.putAll(dbDetails.toEnvMap())
-    out["PROJECT_ID"] = projectID
-    return out
+  override fun appendScriptEnv(env: MutableMap<String, String>) {
+    env.putAll(dbDetails.toEnvMap())
+    env["PROJECT_ID"] = projectID
   }
 }

--- a/service/src/main/kotlin/vdi/service/UninstallHandler.kt
+++ b/service/src/main/kotlin/vdi/service/UninstallHandler.kt
@@ -15,9 +15,10 @@ class UninstallHandler(
   private val vdiID: String,
   private val dbDetails: DatabaseDetails,
   executor:  ScriptExecutor,
+  customPath: String,
   private val script: ScriptConfiguration,
   metrics: ScriptMetrics,
-) : HandlerBase<Unit>(workspace, executor, metrics) {
+) : HandlerBase<Unit>(workspace, executor, customPath, metrics) {
   private val log = LoggerFactory.getLogger(javaClass)
 
   override suspend fun run() {
@@ -49,5 +50,7 @@ class UninstallHandler(
     timer.observeDuration()
   }
 
-  override fun buildScriptEnv() = dbDetails.toEnvMap()
+  override fun appendScriptEnv(env: MutableMap<String, String>) {
+    env.putAll(dbDetails.toEnvMap())
+  }
 }


### PR DESCRIPTION
Adds a new environment variable to the plugin handler server named `CUSTOM_PATH`.  This variable can be set to a string of path entries which will be appended to the `PATH` variable passed to the plugin script executions.